### PR TITLE
Adjusting travis build to use metricly-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-- '6'
+- '8'
+install:
+- npm i -g metricly-cli
 script:
-- npm i git+https://git@github.com/Netuitive/netuitive-package-validator.git; node
-  -e "require('package-validator').validate('.', require('./package.json').id)";
+- metricly package validate
 notifications:
   slack:
     secure: Br8YdIXvgFgy65O5rj4FHF6kUnJoR/RYCs+0WMbVKCgMp03WnidVY709I0eZ0oj0O5pCFSz6Tt7rTBqBL8pGWmrZIo4KI4nfEQ+4LUB0hKxJV0uBV0bPV0inkbwXaFZ45FG5BZgbn3zMh/wvh5EQOxwevMdDpNf49TN6m+/nEqBPXF6DgGKvoL6tG0J/Mx+/Oyb1uh+GJuP6WvmuphUT9UArJB9nz7jGwAEbVFF1BIPF1aobN80DSZO5Lup15kG8rBotf2g/SeuBnKWKjXLGPmi9nYbeKgvGnh/d+pOcC959Z3Q6D+XE9Ph5A6pnvIMX3JOBnF6la6Mdpv9xnnz+1xbQyjAXBGuPdX497lVF1te2xVnHU/dMF5vLn4/0bSMXO/O1W0U16gKMFIv2xqAk/UnrFLW/k+9lfFFY/n90nstmBCnVm/TFTpWokqv0jaYSiA+7LglkAfvjtk4QtaX+9W66ZHtbl6kMh0W7tWVNt4OlwBEEwuGZgFA7aYtFeDabkPoclBT6IXbB36JRWxn3u/HuejNoezSy+xEMv+Ekr8qsBHO6n1lS9kW2tbxI1XMLeH21CVdK4FpxlO2NKNjbWKJRzw++XTOfDcj2VPvRPV/yW+f2QLEld+8U9yhAFm5NlF2qEwvzFNhudl7dVp97UpXs/CM8mpBxrQzA1l6t4qw=

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ For detailed information on this package, please contact [Metricly support](http
 
 ## Release History
 
+### Version next
+
+* Adjusted build to use metricly-cli for validation
+
 ### Version 1.0.0
 
 * Initial production release


### PR DESCRIPTION
Now that we have the metricly-cli we can use it to validate packages.